### PR TITLE
Fix issues and Add features

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,8 +53,10 @@ func BuildConfig(configOpt ConfigOptions, input option.Options) (*option.Options
 		options.Experimental = &option.ExperimentalOptions{
 			ClashAPI: &option.ClashAPIOptions{
 				ExternalController: fmt.Sprintf("%s:%d", "127.0.0.1", configOpt.ClashApiPort),
-				StoreSelected:      true,
-				CacheFile:          "clash.db",
+			},
+			CacheFile: &option.CacheFileOptions{
+				Enabled: true,
+				Path:    "clash.db",
 			},
 		}
 	}
@@ -354,9 +356,10 @@ func BuildConfig(configOpt ConfigOptions, input option.Options) (*option.Options
 		Type: C.TypeURLTest,
 		Tag:  "auto",
 		URLTestOptions: option.URLTestOutboundOptions{
-			Outbounds: tags,
-			URL:       configOpt.ConnectionTestUrl,
-			Interval:  configOpt.URLTestInterval,
+			Outbounds:   tags,
+			URL:         configOpt.ConnectionTestUrl,
+			Interval:    configOpt.URLTestInterval,
+			IdleTimeout: configOpt.URLTestIdleTimeout,
 		},
 	}
 
@@ -408,7 +411,6 @@ func applyOverrides(overrides ConfigOptions, options option.Options) *option.Opt
 	if overrides.EnableClashApi {
 		options.Experimental.ClashAPI = &option.ClashAPIOptions{
 			ExternalController: fmt.Sprintf("%s:%d", "127.0.0.1", overrides.ClashApiPort),
-			StoreSelected:      true,
 		}
 	}
 

--- a/config/option.go
+++ b/config/option.go
@@ -23,6 +23,7 @@ type ConfigOptions struct {
 	TUNStack                string                `json:"tun-stack"`
 	ConnectionTestUrl       string                `json:"connection-test-url"`
 	URLTestInterval         option.Duration       `json:"url-test-interval"`
+	URLTestIdleTimeout      option.Duration       `json:"url-test-idle-timeout"`
 	EnableClashApi          bool                  `json:"enable-clash-api"`
 	ClashApiPort            uint16                `json:"clash-api-port"`
 	EnableTun               bool                  `json:"enable-tun"`
@@ -72,6 +73,7 @@ func DefaultConfigOptions() *ConfigOptions {
 		TUNStack:                "mixed",
 		ConnectionTestUrl:       "https://cp.cloudflare.com/",
 		URLTestInterval:         option.Duration(10 * time.Minute),
+		URLTestIdleTimeout:      option.Duration(100 * time.Minute),
 		EnableClashApi:          true,
 		ClashApiPort:            6756,
 		EnableTun:               true,

--- a/config/outbound.go
+++ b/config/outbound.go
@@ -20,8 +20,8 @@ func patchOutboundMux(base option.Outbound, configOpt ConfigOptions, obj outboun
 			Protocol:   configOpt.MuxProtocol,
 		}
 		obj["multiplex"] = multiplex
-	} else {
-		delete(obj, "multiplex")
+	// } else {
+	// 	delete(obj, "multiplex")
 	}
 	return obj
 }
@@ -41,8 +41,8 @@ func patchOutboundTLSTricks(base option.Outbound, configOpt ConfigOptions, obj o
 
 		if tlsTricks.MixedCaseSNI || tlsTricks.PaddingMode != "" {
 			tls["tls_tricks"] = tlsTricks
-		} else {
-			tls["tls_tricks"] = nil
+		// } else {
+		// 	tls["tls_tricks"] = nil
 		}
 	}
 	return obj
@@ -56,8 +56,8 @@ func patchOutboundFragment(base option.Outbound, configOpt ConfigOptions, obj ou
 			Sleep:   configOpt.TLSTricks.FragmentSleep,
 		}
 		obj["tls_fragment"] = tlsFragment
-	} else {
-		obj["tls_fragment"] = nil
+	// } else {
+	// 	obj["tls_fragment"] = nil
 	}
 	return obj
 }

--- a/custom/service.go
+++ b/custom/service.go
@@ -36,8 +36,6 @@ func NewService(options option.Options) (*libbox.BoxService, error) {
 	ctx = filemanager.WithDefault(ctx, sWorkingPath, sTempPath, sUserID, sGroupID)
 	urlTestHistoryStorage := urltest.NewHistoryStorage()
 	ctx = service.ContextWithPtr(ctx, urlTestHistoryStorage)
-	pauseManager := pause.WithDefaultManager(ctx)
-	// ctx = pause.ContextWithManager(ctx, pauseManager)
 	instance, err := B.New(B.Options{
 		Context: ctx,
 		Options: options,
@@ -51,7 +49,7 @@ func NewService(options option.Options) (*libbox.BoxService, error) {
 		ctx,
 		cancel,
 		instance,
-		pauseManager,
+		service.FromContext[pause.Manager](ctx),
 		urlTestHistoryStorage,
 	)
 	return &service, nil


### PR DESCRIPTION
Fix service.go to work with singbox 1.8.2
Drop deprecated feautre (Clash API: cache_file and store_selected) 
Add feature (Cache File: path)
Add idle_timeout field for URLTest outbound
Refactor outbound.go
Add feature to omit TLSTricks and Fragment on VLESS Reality configs.